### PR TITLE
Arm64 builds

### DIFF
--- a/.github/workflows/sifi_erl.yaml
+++ b/.github/workflows/sifi_erl.yaml
@@ -1,0 +1,40 @@
+name: Simplifi Specific Erlang Builds
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+jobs:
+  build-sync:
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - { DISTRO: "rockylinux", OS_VERSION: "8", PLATFORM: "linux-arm64", RUNNER: "ubuntu-22.04-arm64", ERLANG_VERSION: "26.1.2"}
+          - { DISTRO: "rockylinux", OS_VERSION: "8", PLATFORM: "linux-arm64", RUNNER: "ubuntu-22.04-arm64", ERLANG_VERSION: "25.3.2"}
+          - { DISTRO: "rockylinux", OS_VERSION: "8", PLATFORM: "linux-arm64", RUNNER: "ubuntu-22.04-arm64", ERLANG_VERSION: "24.3.4"}
+    runs-on: ${{ matrix.cfg.RUNNER }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build the package
+        env:
+          ERLANG_VERSION: ${{ matrix.cfg.ERLANG_VERSION }}
+          GPG_PASS: ${{ secrets.GPG_PASS }}
+        run: |
+          echo "Building ..."
+          echo "Distro latest ${{ matrix.cfg.DISTRO }} ${{ matrix.cfg.OS_VERSION }}"
+          echo "Platform ${{ matrix.cfg.PLATFORM }}"
+          echo "${{secrets.GPG_P_KEY}}" | tr ';' '\n' > GPG-KEY-pmanager
+          make "erlang_${{ env.ERLANG_VERSION }}_${{matrix.cfg.DISTRO}}_${{matrix.cfg.OS_VERSION}}_${{matrix.cfg.PLATFORM}}"
+          find ./ -type f -name "GPG-KEY*" -delete
+
+      - id: upload-to-artifactory
+        run: |
+          curl -L -u${{ secrets.JFROG_USER }}:${{ secrets.JFROG_API_KEY }} -XPUT https://sifi.jfrog.io/artifactory/rpm-local/${{ matrix.cfg.DISTRO }}/${{ matrix.cfg.OS_VERSION }}/ -T build/${{ matrix.cfg.DISTRO }}/${{ matrix.cfg.OS_VERSION }}/*


### PR DESCRIPTION
Create ARM-based sifi-specific builds

I've actually hacked this to run already and it works, but this will create a clean PR'd workflow to go to master.

Ultimately I think we should move to using elixir burrito builds, or at least the erlang's provided by them.  But I think this is a good baby step to restoring sanity to our current rocky 8 setup.